### PR TITLE
Remove accidental bash dependency in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository copies sources from upstream, with no patches.
  * C++ compiler capable of building LLVM, Clang, and LLD from source
  * cmake 3.4.3 or later
  * make
- * POSIX shell
+ * POSIX system (sh, echo, cut, tr)
 
 ## Build Instructions
 

--- a/build
+++ b/build
@@ -10,7 +10,7 @@ ROOTDIR="$(pwd)"
 
 TARGET_OS_AND_ABI=${TARGET#*-} # Example: linux-gnu
 TARGET_OS_LOWER=${TARGET_OS_AND_ABI%-*} # Example: linux
-TARGET_OS_CMAKE=${TARGET_OS_LOWER^} # Example: Linux
+TARGET_OS_CMAKE=$(echo "$TARGET_OS_LOWER" | cut -c1 | tr a-z A-Z)$(echo "$TARGET_OS_LOWER" | cut -c2-) # Example: Linux
 
 # First build the libraries for Zig to link against, as well as native `llvm-tblgen`.
 mkdir -p "$ROOTDIR/out/build-llvm-host"


### PR DESCRIPTION
Fixes #22.

POSIX method for uppercasing taken from here:
https://stackoverflow.com/questions/12420317/first-character-of-a-variable-in-a-shell-script-to-uppercase