### PR TITLE
Add simple patch for OS renames

### DIFF
--- a/build
+++ b/build
@@ -10,6 +10,8 @@ ROOTDIR="$(pwd)"
 
 TARGET_OS_AND_ABI=${TARGET#*-} # Example: linux-gnu
 TARGET_OS_LOWER=${TARGET_OS_AND_ABI%-*} # Example: linux
+TARGET_OS_LOWER="${TARGET_OS_LOWER/macos/darwin}" # cmake expects Darwin rather than macos
+TARGET_OS_LOWER="${TARGET_OS_LOWER/freebsd/freeBSD}" # cmake expects FreeBSD rather than freebsd
 TARGET_OS_CMAKE=$(echo "$TARGET_OS_LOWER" | cut -c1 | tr a-z A-Z)$(echo "$TARGET_OS_LOWER" | cut -c2-) # Example: Linux
 
 # First build the libraries for Zig to link against, as well as native `llvm-tblgen`.


### PR DESCRIPTION
This commit adds a simplistic patch to OS renaming problem on macos and freebsd. Namely, with this patch we generate correct mapping for cmake:

* macos -> Darwin
* freebsd -> FreeBSD

As an added bonus, this solution doesn't require any additional external tools.

Fixes #36

