### PR TITLE
remove bash dependency (pattern substitution)

### DIFF
--- a/build
+++ b/build
@@ -13,10 +13,12 @@ TARGET_OS_AND_ABI=${TARGET#*-} # Example: linux-gnu
 
 # Here we map the OS from the target triple to the value that CMake expects.
 TARGET_OS_CMAKE=${TARGET_OS_AND_ABI%-*} # Example: linux
-TARGET_OS_CMAKE="${TARGET_OS_CMAKE/macos/Darwin}"
-TARGET_OS_CMAKE="${TARGET_OS_CMAKE/freebsd/FreeBSD}"
-TARGET_OS_CMAKE="${TARGET_OS_CMAKE/windows/Windows}"
-TARGET_OS_CMAKE="${TARGET_OS_CMAKE/linux/Linux}"
+case $TARGET_OS_CMAKE in
+  macos) TARGET_OS_CMAKE="Darwin";;
+  freebsd) TARGET_OS_CMAKE="FreeBSD";;
+  windows) TARGET_OS_CMAKE="Windows";;
+  linux) TARGET_OS_CMAKE="Linux";;
+esac
 
 # First build the libraries for Zig to link against, as well as native `llvm-tblgen`.
 mkdir -p "$ROOTDIR/out/build-llvm-host"


### PR DESCRIPTION
Pattern substitution in parameter expansion is not part of POSIX sh.
E.g. `dash` was failing with "Bad substitution".

At first I was skeptical whether adding a `case` statement would be fine as it is a control flow statement and this should be a simple, linear build script. However, my other attempts at solving this were not as readable or required external commands such as `sed`.

Fixes #39 and corresponding `shellcheck` warnings