### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ For other versions, check the git tags of this repository.
 
 ## Host System Dependencies
 
- * C++ compiler capable of building LLVM, Clang, and LLD from source
- * cmake 3.4.3 or later
+ * C++ compiler capable of building LLVM, Clang, and LLD from source (GCC 5.1+)
+ * cmake 3.13.4 or later
  * make
  * POSIX system (bash, mkdir, cd)
- * Python
+ * Python 3
 
 ## Build Instructions
 


### PR DESCRIPTION
adjusted host dependencies for 0.8.0

* python 3 is now a requirement
* cmake 3.13.4 or higher is now a requirement
* including a hint to use gcc 5.1+