### PR TITLE
x86_64-netbsd-none hacks

### DIFF
--- a/build
+++ b/build
@@ -132,6 +132,6 @@ cmake "$ROOTDIR/zig" \
   -DZIG_VERSION="$ZIG_VERSION" \
   -DZIG_USE_LLVM_CONFIG=OFF \
   -DZIG_STATIC_ZLIB=ON
+make "$JOBS" install
 unset CC
 unset CXX
-make "$JOBS" install

--- a/build
+++ b/build
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 set -e
+set -u
+set -x
 
 JOBS="$1"
 TARGET="$2" # Example: riscv64-linux-gnu

--- a/build
+++ b/build
@@ -56,8 +56,16 @@ make "$JOBS" install
 
 # Now we have Zig as a cross compiler.
 ZIG="$ROOTDIR/out/host/bin/zig"
-export CC="$ZIG cc -fno-sanitize=all -target $TARGET -mcpu=$MCPU"
-export CXX="$ZIG c++ -fno-sanitize=all -target $TARGET -mcpu=$MCPU"
+export CC="$ZIG cc -fno-sanitize=all -mcpu=$MCPU"
+export CXX="$ZIG c++ -fno-sanitize=all -mcpu=$MCPU"
+echo "#!/bin/sh
+env CC=\"clang\" $CC \"\$@\"" > $ROOTDIR/out/host/bin/zigcc
+echo "#!/bin/sh
+env CC=\"clang\" $CXX \"\$@\"" > $ROOTDIR/out/host/bin/zigcxx
+chmod +x $ROOTDIR/out/host/bin/zigcc
+chmod +x $ROOTDIR/out/host/bin/zigcxx
+export CC="$ROOTDIR/out/host/bin/zigcc"
+export CXX="$ROOTDIR/out/host/bin/zigcxx"
 
 # First cross compile zlib for the target, as we need the LLVM linked into
 # the finaly zig binary to have zlib support enabled.

--- a/build
+++ b/build
@@ -18,6 +18,7 @@ TARGET_OS_CMAKE=${TARGET_OS_AND_ABI%-*} # Example: linux
 case $TARGET_OS_CMAKE in
   macos) TARGET_OS_CMAKE="Darwin";;
   freebsd) TARGET_OS_CMAKE="FreeBSD";;
+  netbsd) TARGET_OS_CMAKE="NetBSD";;
   windows) TARGET_OS_CMAKE="Windows";;
   linux) TARGET_OS_CMAKE="Linux";;
   native) TARGET_OS_CMAKE="";;

--- a/llvm/lib/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/CMakeLists.txt
@@ -144,6 +144,7 @@ add_llvm_target(AMDGPUCodeGen
   GCNNSAReassign.cpp
   GCNDPPCombine.cpp
   SIModeRegister.cpp
+  sincos_netbsd_compat.c
 
   LINK_COMPONENTS
   Analysis

--- a/llvm/lib/Target/AMDGPU/sincos_netbsd_compat.c
+++ b/llvm/lib/Target/AMDGPU/sincos_netbsd_compat.c
@@ -1,0 +1,16 @@
+#include <math.h>
+
+void sincos(double x, double *sin_result, double *cos_result) {
+	*sin_result = sin(x);
+	*cos_result = cos(x);
+}
+
+void sincosf(float x, float *sin_result, float *cos_result) {
+	*sin_result = sinf(x);
+	*cos_result = cosf(x);
+}
+
+void sincosl(long double x, long double *sin_result, long double *cos_result) {
+	*sin_result = sinl(x);
+	*cos_result = cosl(x);
+}

--- a/zig/cmake/install.cmake
+++ b/zig/cmake/install.cmake
@@ -10,7 +10,7 @@ if(NOT EXISTS ${zig_EXE})
     message(FATAL_ERROR)
 endif()
 
-execute_process(COMMAND ${zig_EXE} ${ZIG_INSTALL_ARGS}
+execute_process(COMMAND env CC=clang ${zig_EXE} ${ZIG_INSTALL_ARGS}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     RESULT_VARIABLE _result
 )


### PR DESCRIPTION
The changes here is the result of me attempting to run zig-bootstrap in a NetBSD x86_64 environment, targeting NetBSD x86_64 (so, building LLVM and Zig for the host system, and then cross-compiling LLVM and Zig to the same host system). Running, finding errors, fixing, and repeating step 1.

This should not be merged (hence why I'm starting with a draft PR).

There are comments on commits explaining the build issues that created those fixes. At a high level:
 - Shell best practices. `set -u` to prevent typos blowing up, and `set -x` to aid debugging to see which variables are being passed to the commands.
 - Pass on that we are on NetBSD to cmake via the `$TARGET_OS_CMAKE` mapping.
 - Use clang instead of gcc. `-mcpu=baseline` is not supported in gcc (tested in gcc7, shipped by netbsd, and gcc10, from my linux system).
   - Should not be merged as the README declares that GCC should work: "C++ compiler capable of building LLVM, Clang, and LLD from source (GCC 5.1+)"
  - Add `sincos_netbsd_compat.c` to LLVM sourcecode. LLVM mistakengly optimizes `sin(x); cos(x);` to `sincos(x)` on a target that does not have it (glibc, musl, freebsd have it, netbsd does not).
    - Disabling the AMDGPU backend to fix it (which is where the `undefined symbol: sincos` error comes from) does not work, as Zig requires all of the LLVM default targets to be enabled.
    - Should not be merged as this would break the platforms that have `sincos` due to duplicate symbols? I haven't tested it. Maybe this could be added *only* for NetBSD? I'm not sure how CMake works.
 - Let the final `make "$JOBS" install` step have the correct `CC` and `CXX` variables. This reverts the second half of https://github.com/ziglang/zig-bootstrap/commit/dc5d64628db836b4eda172426298c5911f0ad96a.
   - Sadly, I no longer remember why I did this. It's possible that it would still work, as the configure step has the variables?