### PR TITLE
ASM/CC/CXX: pass over environment variables

### DIFF
--- a/build
+++ b/build
@@ -57,6 +57,15 @@ make "$JOBS" install
 # Now we have Zig as a cross compiler.
 ZIG="$ROOTDIR/out/host/bin/zig"
 
+# cmake 3.19+ accepts -DCMAKE_C_COMPILER, -DCMAKE_CXX_COMPILER,
+# -DCMAKE_ASM_COMPILER with spaces. However, cmake 3.19 is not ubiquitous yet.
+# The exports below can be replaced with variables to cmake once we decide
+# that cmake 3.19+ is in most new distributions.
+
+export ASM="$ZIG cc -fno-sanitize=all -s -target $TARGET -mcpu=$MCPU"
+export CC="$ZIG cc -fno-sanitize=all -s -target $TARGET -mcpu=$MCPU"
+export CXX="$ZIG cc -fno-sanitize=all -s -target $TARGET -mcpu=$MCPU"
+
 # First cross compile zlib for the target, as we need the LLVM linked into
 # the final zig binary to have zlib support enabled.
 mkdir -p "$ROOTDIR/out/build-zlib-$TARGET-$MCPU"
@@ -67,9 +76,6 @@ cmake "$ROOTDIR/zlib" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CROSSCOMPILING=True \
   -DCMAKE_SYSTEM_NAME="$TARGET_OS_CMAKE" \
-  -DCMAKE_C_COMPILER="$ZIG;cc;-fno-sanitize=all;-s;-target;$TARGET;-mcpu=$MCPU" \
-  -DCMAKE_CXX_COMPILER="$ZIG;c++;-fno-sanitize=all;-s;-target;$TARGET;-mcpu=$MCPU" \
-  -DCMAKE_ASM_COMPILER="$ZIG;cc;-fno-sanitize=all;-s;-target;$TARGET;-mcpu=$MCPU" \
   -DCMAKE_RC_COMPILER="$ROOTDIR/out/host/bin/llvm-rc" \
   -DCMAKE_AR="$ROOTDIR/out/host/bin/llvm-ar" \
   -DCMAKE_RANLIB="$ROOTDIR/out/host/bin/llvm-ranlib"
@@ -91,9 +97,6 @@ cmake "$ROOTDIR/llvm" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CROSSCOMPILING=True \
   -DCMAKE_SYSTEM_NAME="$TARGET_OS_CMAKE" \
-  -DCMAKE_C_COMPILER="$ZIG;cc;-fno-sanitize=all;-s;-target;$TARGET;-mcpu=$MCPU" \
-  -DCMAKE_CXX_COMPILER="$ZIG;c++;-fno-sanitize=all;-s;-target;$TARGET;-mcpu=$MCPU" \
-  -DCMAKE_ASM_COMPILER="$ZIG;cc;-fno-sanitize=all;-s;-target;$TARGET;-mcpu=$MCPU" \
   -DCMAKE_RC_COMPILER="$ROOTDIR/out/host/bin/llvm-rc" \
   -DCMAKE_AR="$ROOTDIR/out/host/bin/llvm-ar" \
   -DCMAKE_RANLIB="$ROOTDIR/out/host/bin/llvm-ranlib" \


### PR DESCRIPTION
ASM is now required by llvm. Commit 50aa139d14 moved CC, CXX to cmake's variables and introduced CMAKE_ASM_COMPILER. However, as noted in the build script, it requires cmake 3.19[1], which is not yet ubiquitous.

Roll back to env vars until, say, 2025, when ubuntu 20.04 gets EOLd? The cutoff date is up for negotiation; I just picked something that my inner circle still uses quite a bit.

[1]: https://cmake.org/cmake/help/latest/release/3.19.html#other-changes