### PR TITLE
Fix build path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For other versions, check the git tags of this repository.
 ## Build Instructions
 
 ```
-build -j1 <arch>-<os>-<abi> baseline
+./build -j1 <arch>-<os>-<abi> baseline
 ```
 
 All parameters are required:


### PR DESCRIPTION
Dumbest PR ever, but I actually tripped up because I didn't notice `build` was a local script, not a system command.

Might save someone else 5 seconds of confusion.