### PR TITLE
build.bat updates for compatibility with the llvm16 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 out/
+out-win/
+out-win-x86/
 zig-cache

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The script must be run within the `Developer Command Prompt for VS 2019` shell:
 build.bat <arch>-<os>-<abi> <mcpu>
 ```
 
+To build for x86 Windows, run the script within the `x86 Native Tools Command Prompt for VS 2019`.
+
 ### Supported Triples
 
 If you try a "not tested" one and find a problem please file an issue,


### PR DESCRIPTION
- add -fno-stack-protector arg to get around missing `__stack_chk_guard`/`__stack_chk_fail` symbols when using zig cc
- set `ZIG_LIB_DIR` so installation can be found during `zig cc`
- add `-DLLVM_INCLUDE_UTILS=OFF`
- reorder cmake args in build.bat to match build for easier diffing
- support building on x86 (however zig2 runs out of memory)