### PR TITLE
Add copy-pastable build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ For other versions, check the git tags of this repository.
 
 ## Build Instructions
 
+TL;DR:
+
+```
+CMAKE_GENERATOR=Ninja ./build native-linux-gnu baseline
+./out/zig-x86_64-linux-gnu-baseline/zig version
+```
+
+### UNIX Build Instructions
+
 ```
 ./build <arch>-<os>-<abi> <mcpu>
 ```
@@ -60,7 +69,7 @@ significantly affect how long it takes to build:
 
 When it succeeds, output can be found in `out/zig-<triple>-<cpu>/`.
 
-## Windows Build Instructions
+### Windows Build Instructions
 
 Bootstrapping on Windows with MSVC is also possible via `build.bat`, which
 takes the same arguments as `build` above.


### PR DESCRIPTION
The main value here is to put `CMAKE_GENERATOR=Ninja` front-and-center, so that users realize that extra steps are needed for a parallel build.

It _is_ documented quite clearly already, but, from my very personal experience:

* people don't read the docs and spend hours hammering one poor core
* even if people do read the docs, when the come back to the repo the second time around, they forget, and hammer that single poor core _again_ :-)