### PR TITLE
It is possible to bootstrap loongarch64 for linux now

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ is more portable across Linux distributions.
 | `armeb-linux-gnueabihf`    | [#97](https://github.com/ziglang/zig-bootstrap/issues/97) |
 | `armeb-linux-musleabi`     | [#98](https://github.com/ziglang/zig-bootstrap/issues/98) |
 | `armeb-linux-musleabihf`   | [#99](https://github.com/ziglang/zig-bootstrap/issues/99) |
-| `loongarch64-linux-gnu`    | [#166](https://github.com/ziglang/zig-bootstrap/issues/166) |
-| `loongarch64-linux-musl`   | [#164](https://github.com/ziglang/zig-bootstrap/issues/164) |
+| `loongarch64-linux-gnu`    | OK             |
+| `loongarch64-linux-musl`   | OK             |
 | `mips-linux-gnueabi`       | OK             |
 | `mips-linux-gnueabihf`     | OK             |
 | `mips-linux-musl`          | OK             |


### PR DESCRIPTION
With https://github.com/ziglang/zig-bootstrap/commit/1ad232c5a2e1ebbdad2cfbb86ad8fe7f73c7e4d4 , it is possible to bootstrap loongarch64 for linux now.

Closes #164 and #166 